### PR TITLE
fix: redis auth + safe mail config

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -6,10 +6,10 @@ spring:
     driver-class-name: org.postgresql.Driver
 
   mail:
-    host: ${MAIL_HOST}
-    port: ${MAIL_PORT}
-    username: ${MAIL_USERNAME}
-    password: ${MAIL_PASSWORD}
+    host: ${MAIL_HOST:}
+    port: ${MAIL_PORT:}
+    username: ${MAIL_USERNAME:}
+    password: ${MAIL_PASSWORD:}
     properties:
       mail:
         smtp:
@@ -21,6 +21,7 @@ spring:
     redis:
       host: redis
       port: 6379
+      password: ${SPRING_DATA_REDIS_PASSWORD}
       timeout: 2000
 
   jpa:


### PR DESCRIPTION
### **🔥 What Changed (Precise)**

**1️⃣ Mail config made safe**

`host: ${MAIL_HOST:}`

_👉 Prevents startup crash if env is missing_

=============================
**2️⃣ Redis password added (CRITICAL FIX)**

`password: ${SPRING_DATA_REDIS_PASSWORD}`

_👉 This is why your health was DOWN_